### PR TITLE
Refactored: Migrated from Oracle VirtualBox to VMWare Workstation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore Packer and Terraform secret variable files
-*.pkrvars.hcl
+packer/secret.auto.pkrvars.hcl
 *.tfvars
 
 # Ignore folder for output *.vdi

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ packer-playground/output
 terraform.tfstate
 terraform.tfstate.backup
 
+terraform/vms
+
 # VSCode
 .vscode

--- a/entry.sh
+++ b/entry.sh
@@ -6,17 +6,51 @@ set -e -u
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 readonly PACKER_DIR="${SCRIPT_DIR}/packer"
-readonly PACKER_VM_NAME="ubuntu-server-24-template"
-readonly PACKER_OUTPUT_DIR="${PACKER_DIR}/output/ubuntu-server"
+readonly PACKER_VM_NAME="vmware-ubuntu-server-24-template"
+readonly PACKER_OUTPUT_DIR="${PACKER_DIR}/output/ubuntu-server-vmware"
 
-# Function: Purge inaccessible VirtualBox hard disks
-purge_vbox_hdds() {
-  echo ">>> STEP: Purging all inaccessible VirtualBox hard disks..."
-  VBoxManage list hdds | awk -v RS= '/inaccessible/ {print $2}' | while read -r uuid; do
-    echo "Removing inaccessible HDD with UUID: $uuid"
-    VBoxManage closemedium disk "$uuid" --delete || echo "Warning: Failed to remove medium $uuid. It might already be gone."
-  done
-  echo "VirtualBox media registry cleaned."
+# Function: Clean up VMware Workstation VM registrations
+cleanup_vmware_vms() {
+  echo ">>> STEP: Cleaning up VMware Workstation VM registrations..."
+  if vmrun list | grep -q "$PACKER_VM_NAME"; then
+    echo "Found leftover Packer VM '$PACKER_VM_NAME'. Stopping and deleting..."
+    vmrun stop "${PACKER_OUTPUT_DIR}/${PACKER_VM_NAME}.vmx" hard || true
+    vmrun delete "${PACKER_OUTPUT_DIR}/${PACKER_VM_NAME}.vmx" || true
+  else
+    echo "No leftover Packer VM found. Skipping VMware cleanup."
+  fi
+  echo "--------------------------------------------------"
+}
+
+# Function: Clean up Packer output directory
+cleanup_packer_output() {
+  echo ">>> STEP: Cleaning Packer output directory..."
+  cd "${PACKER_DIR}"
+  rm -rf "${PACKER_OUTPUT_DIR}"
+  echo "Packer output directory cleaned."
+  echo "--------------------------------------------------"
+}
+
+# Function: Execute Packer build
+build_packer() {
+  echo ">>> STEP: Starting new Packer build..."
+  cd "${PACKER_DIR}"
+  packer init .
+  packer build -var-file=common.pkrvars.hcl .
+  echo "Packer build complete. New base image (VMX) is ready."
+  echo "--------------------------------------------------"
+}
+
+# Function: Reset Terraform state
+reset_terraform_state() {
+  echo ">>> STEP: Resetting Terraform state..."
+  cd "${TERRAFORM_DIR}"
+  rm -rf ~/.terraform/vmware
+  rm -rf .terraform
+  rm -f .terraform.lock.hcl
+  rm -f terraform.tfstate
+  rm -f terraform.tfstate.backup
+  echo "Terraform state reset."
   echo "--------------------------------------------------"
 }
 
@@ -27,64 +61,6 @@ destroy_terraform_resources() {
   terraform init -upgrade
   terraform destroy -parallelism=1 -auto-approve -lock=false
   echo "Terraform destroy complete."
-  echo "--------------------------------------------------"
-}
-
-# Function: Clean up Packer artifacts
-cleanup_packer_artifacts() {
-  echo ">>> STEP: Cleaning up old Packer artifacts from VirtualBox..."
-  if VBoxManage showvminfo "$PACKER_VM_NAME" >/dev/null 2>&1; then
-    echo "Found leftover Packer VM '$PACKER_VM_NAME'. Unregistering and deleting..."
-    VBoxManage unregistervm "$PACKER_VM_NAME" --delete
-  else
-    echo "No leftover Packer VM found. Skipping VirtualBox cleanup."
-  fi
-  echo "--------------------------------------------------"
-}
-
-# Function: Clean up Packer output directory
-cleanup_packer_output() {
-  echo ">>> STEP: Cleaning output directory..."
-  cd "${PACKER_DIR}"
-  find ~/.cache/packer -mindepth 1 ! -name '*.iso' -exec rm -rf {} +
-  rm -rf output/ubuntu-server
-  echo "--------------------------------------------------"
-}
-
-# Function: Execute Packer build
-build_packer() {
-  echo ">>> STEP: Starting new Packer build..."
-  cd "${PACKER_DIR}"
-  packer build .
-  echo "Packer build complete. New base image is ready."
-  echo "--------------------------------------------------"
-}
-
-# Function: Unpack OVA file
-unpack_ova() {
-  echo ">>> STEP: Unpacking OVA to bypass provider bug..."
-  cd "${PACKER_OUTPUT_DIR}"
-  shopt -s nullglob
-  ova_files=(./*.ova)
-  shopt -u nullglob
-  if [ ${#ova_files[@]} -ne 1 ]; then
-    echo "Error: Expected exactly one OVA file in ${PACKER_OUTPUT_DIR}, but found ${#ova_files[@]}." >&2
-    exit 1
-  fi
-  tar -xvf "${ova_files[0]}"
-  echo "Unpacking complete. .ovf and .vmdk are now available."
-  cd "${SCRIPT_DIR}"
-  echo "--------------------------------------------------"
-}
-
-# Function: Reset Terraform state
-reset_terraform_state() {
-  echo ">>> STEP: Resetting Terraform state..."
-  cd "${TERRAFORM_DIR}"
-  rm -rf ~/.terraform/virtualbox
-  rm -rf .terraform
-  rm -f .terraform.lock.hcl
-  rm -f terraform.tfstate
   echo "--------------------------------------------------"
 }
 
@@ -100,14 +76,13 @@ apply_terraform() {
 
 # Function: Verify SSH connections
 verify_ssh() {
-  echo ">>> STEP: Pruning and reconfiguring SSH connection..."
-  start_ip=101
-  end_ip=103
+  echo ">>> STEP: Pruning and reconfiguring SSH connections..."
   user=$(whoami)
   known_hosts_file="/home/$user/.ssh/known_hosts"
-
+  start_ip=101
+  end_ip=103
   for ip in $(seq $start_ip $end_ip); do
-    host="192.168.56.$ip"
+    host="172.16.134.$ip"
     echo "Processing host: $host"
     if [ -f "$known_hosts_file" ]; then
       echo "Removing old keys for $host from $known_hosts_file..."
@@ -116,7 +91,7 @@ verify_ssh() {
       echo "known_hosts file does not exist: $known_hosts_file"
     fi
     echo "Connecting to $host via SSH and executing command..."
-    ssh "$user@$host" "ip a show enp0s8 | grep 'inet ' && hostname" || echo "Failed to connect to $host or command execution failed."
+    ssh -o ConnectTimeout=10 "$user@$host" "ip a show ens37 | grep 'inet ' && hostname" || echo "Failed to connect to $host or command execution failed."
   done
   echo "--------------------------------------------------"
 }
@@ -132,16 +107,15 @@ prompt_verify_ssh() {
 }
 
 # Main menu
-echo "VirtualBox VM Management Script"
+echo "VMware Workstation VM Management Script"
 PS3="Please select an action: "
-options=("Reset All" "Rebuild All" "Rebuild Terraform" "Verify SSH" "Quit")
+options=("Reset All" "Rebuild All" "Rebuild Packer" "Rebuild Terraform" "Verify SSH" "Quit")
 select opt in "${options[@]}"; do
   case $opt in
     "Reset All")
       echo "Executing Reset All workflow..."
-      purge_vbox_hdds
+      cleanup_vmware_vms
       destroy_terraform_resources
-      cleanup_packer_artifacts
       cleanup_packer_output
       reset_terraform_state
       echo "Reset All workflow completed successfully."
@@ -149,23 +123,26 @@ select opt in "${options[@]}"; do
       ;;
     "Rebuild All")
       echo "Executing Rebuild All workflow..."
-      purge_vbox_hdds
+      cleanup_vmware_vms
       destroy_terraform_resources
-      cleanup_packer_artifacts
       cleanup_packer_output
       build_packer
-      unpack_ova
       reset_terraform_state
       apply_terraform
       prompt_verify_ssh
       echo "Rebuild All workflow completed successfully."
       break
       ;;
+    "Rebuild Packer")
+      echo "Executing Rebuild Packer workflow..."
+      cleanup_vmware_vms
+      cleanup_packer_output
+      build_packer
+      break
+      ;;
     "Rebuild Terraform")
       echo "Executing Rebuild Terraform workflow..."
-      purge_vbox_hdds
       destroy_terraform_resources
-      cleanup_packer_artifacts
       reset_terraform_state
       apply_terraform
       prompt_verify_ssh

--- a/entry.sh
+++ b/entry.sh
@@ -29,6 +29,10 @@ cleanup_vmware_vms() {
 cleanup_packer_output() {
   echo ">>> STEP: Cleaning Packer output directory..."
   cd "${PACKER_DIR}"
+  if [ -d ~/.cache/packer ]; then
+    echo "Cleaning Packer cache, preserving ISOs..."
+    find ~/.cache/packer -mindepth 1 ! -name '*.iso' -exec rm -rf {} + || true
+  fi
   rm -rf "${PACKER_OUTPUT_DIR}"
   echo "Packer output directory cleaned."
   echo "--------------------------------------------------"

--- a/packer/common.pkrvars.hcl
+++ b/packer/common.pkrvars.hcl
@@ -1,0 +1,12 @@
+
+vm_name       = "ubuntu-server-24-template-vmware"
+guest_os_type = "ubuntu-64"
+
+iso_url      = "https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso"
+iso_checksum = "sha256:d6dab0c3a657988501b4bd76f1297c053df710e06e0c3aece60dead24f270b4d"
+
+cpus      = 4
+memory    = 4096 
+disk_size = 40960
+
+disk_adapter_type = "scsi"

--- a/packer/http/user-data
+++ b/packer/http/user-data
@@ -14,16 +14,12 @@ autoinstall:
   network:
     version: 2
     ethernets:
-      enp0s3:
+      ens33:
         dhcp4: true
-      enp0s8:
-        dhcp4: false
-        addresses:
-          - 192.168.56.88/24
 
   # User and Hostname Configuration
   identity:
-    hostname: ubuntu-template
+    hostname: ubuntu-server-template
     username: ${username}
     password: ${password_hash}
 

--- a/packer/playbooks/provision.yml
+++ b/packer/playbooks/provision.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Test installing Guest Additions from Ubuntu's official repository"
+- name: "Install and configure VMware Tools for Ubuntu"
   hosts: all
   become: true
   tasks:
@@ -21,10 +21,10 @@
         state: present
         update_cache: true
 
-    - name: "3. Action: Install Guest Additions from Ubuntu repository"
+    - name: "3. Action: Install open-vm-tools from Ubuntu repository"
       ansible.builtin.apt:
         name:
-          - virtualbox-guest-utils
+          - open-vm-tools
         state: present
         update_cache: true
       notify:
@@ -38,16 +38,16 @@
       register: lsmod_result
       changed_when: false
 
-    - name: "5.b Verify: Assert that 'vboxguest' is in the list of loaded modules"
+    - name: "5.b Verify: Assert that 'vmw_balloon' is in the list of loaded modules"
       ansible.builtin.assert:
         that:
-          - "'vboxguest' in lsmod_result.stdout"
-        fail_msg: "Verification failed: vboxguest kernel module is not loaded."
-        success_msg: "Verification successful: vboxguest kernel module is loaded."
+          - "'vmw_balloon' in lsmod_result.stdout"
+        fail_msg: "Verification failed: vmw_balloon kernel module is not loaded."
+        success_msg: "Verification successful: vmw_balloon kernel module is loaded."
 
     - name: "6. Harden: Ensure sshd service is enabled and starts on boot"
       ansible.builtin.systemd:
-        name: ssh  # or ssh.service
+        name: ssh
         state: started
         enabled: true
 
@@ -55,7 +55,7 @@
     - name: "Reboot the machine"
       listen: "Reboot the machine"
       ansible.builtin.reboot:
-        msg: "Rebooting machine to finalize Guest Additions installation."
+        msg: "Rebooting machine to finalize open-vm-tools installation."
         connect_timeout: 5
         reboot_timeout: 600
         pre_reboot_delay: 0

--- a/packer/playbooks/provision.yml
+++ b/packer/playbooks/provision.yml
@@ -38,12 +38,13 @@
       register: lsmod_result
       changed_when: false
 
-    - name: "5.b Verify: Assert that 'vmw_balloon' is in the list of loaded modules"
+    - name: "5.b Verify: Assert that VMware modules are loaded"
       ansible.builtin.assert:
         that:
           - "'vmw_balloon' in lsmod_result.stdout"
-        fail_msg: "Verification failed: vmw_balloon kernel module is not loaded."
-        success_msg: "Verification successful: vmw_balloon kernel module is loaded."
+          - "'e1000' in lsmod_result.stdout"
+        fail_msg: "Verification failed: VMware kernel modules are not loaded."
+        success_msg: "Verification successful: VMware kernel modules are loaded."
 
     - name: "6. Harden: Ensure sshd service is enabled and starts on boot"
       ansible.builtin.systemd:

--- a/packer/plugin.pkr.hcl
+++ b/packer/plugin.pkr.hcl
@@ -1,11 +1,12 @@
 packer {
+  required_version = ">= 1.7.0"
   required_plugins {
-    virtualbox = {
-      version = "~> 1"
-      source  = "github.com/hashicorp/virtualbox"
+    vmware = {
+      version = ">= 1.2.0"
+      source  = "github.com/hashicorp/vmware"
     }
     ansible = {
-      version = "~> 1"
+      version = ">= 1.1.0"
       source  = "github.com/hashicorp/ansible"
     }
   }

--- a/packer/ubuntu-server-24.pkr.hcl
+++ b/packer/ubuntu-server-24.pkr.hcl
@@ -1,5 +1,5 @@
 
-source "virtualbox-iso" "ubuntu-server" {
+source "vmware-iso" "ubuntu-server" {
   # Guest OS & VM Naming
   guest_os_type = var.guest_os_type
   vm_name       = var.vm_name
@@ -15,13 +15,10 @@ source "virtualbox-iso" "ubuntu-server" {
   headless  = false
 
   # Hardware Interfaces
-  hard_drive_interface     = "sata"
-  hard_drive_discard       = true
-  hard_drive_nonrotational = true
-  gfx_controller           = "vboxsvga"
-
-  # guest_additions_mode = "upload"
-  # guest_additions_path = "/tmp/VBoxGuestAdditions.iso"
+  disk_type_id         = "0" # Growable virtual disk contained in a single file (monolithic sparse).
+  disk_adapter_type    = "scsi"
+  network              = "nat" # For external internet connection during installation.
+  network_adapter_type = "e1000" # Recommended values are e1000 and vmxnet3. Defaults to e1000.
   
   # HTTP Content Delivery for cloud-init
   http_content = {
@@ -42,11 +39,6 @@ source "virtualbox-iso" "ubuntu-server" {
     "<f10>"
   ]
 
-  vboxmanage = [
-    ["modifyvm", "{{.Name}}", "--vram", "20"],
-    ["modifyvm", "{{.Name}}", "--nic2", "hostonly", "--hostonlyadapter2", "vboxnet0"]
-  ]
-
   # SSH Configuration for Provisioning
   ssh_username = var.ssh_username
   ssh_password = var.ssh_password
@@ -54,13 +46,13 @@ source "virtualbox-iso" "ubuntu-server" {
 
   # Shutdown & Output Configuration
   shutdown_command = "sudo shutdown -P now"
-  output_directory = "output/ubuntu-server"
-  format           = "ova"
+  output_directory = "output/ubuntu-server-vmware"
+  format           = "vmx"
   keep_registered  = false
 }
 
 build {
-  sources = ["source.virtualbox-iso.ubuntu-server"]
+  sources = ["source.vmware-iso.ubuntu-server"]
 
   provisioner "ansible" {
     playbook_file = "./playbooks/provision.yml"

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -10,7 +10,6 @@ variable "vm_name" {
 
 variable "guest_os_type" {
   type        = string
-  default     = "Ubuntu_64"
   description = "The guest OS type for VirtualBox."
 }
 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -20,25 +20,3 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
   ]
 }
-
-provider "registry.terraform.io/terra-farm/virtualbox" {
-  version     = "0.2.2-alpha.1"
-  constraints = "0.2.2-alpha.1"
-  hashes = [
-    "h1:v7TbaC4KgI/Y/29FqYHeb1pt8yX5KOBvs4+ohW/U6tk=",
-    "zh:0a584e8c4f74f09af41cbd37ac3634582ad45de68b9801f5585ec53af2efdc74",
-    "zh:1d7fff5298e7d2066a9f2f5bbe5307332a819b851bec886604d65a247060a2f1",
-    "zh:2771401dc0c7cb5cdc4896b772c8779663667316cd8d5b7ede9709022878982d",
-    "zh:4343f647324fd5ebd4b9b2fae910672f91552cabbd3be3793b1dce896b89a267",
-    "zh:6b5b5ed5fbd3be4eec2a304f8b256332332334b9dfaa0a5ede913c3fe8cadf07",
-    "zh:74248ba6bc6d8d83fca368dc57eba5009a03636c77a953cf41c00ebe846e0182",
-    "zh:830e74811e5344ace35c9a037eee43904c576117995b700e586c6eeffe9a11b6",
-    "zh:8d8be066ac7bbe37f77558b9a02a70fcf672ef8e22d7e9b78cfbbb88d1e37e47",
-    "zh:9534770abe51cfc4395ca6444b042b70a23b0ee385e75f95716d0a04c46c27e9",
-    "zh:9b401d05ea69f68b00441469f342d4044669100c4499f0562630b9759824d0a8",
-    "zh:b7d162aa98fb73a6cc351537896dacccb8c63213f3cc7e7a54e276e352c5baeb",
-    "zh:cb9589ab874b3ce9b6509c06167a7f6e06ee942ab7079098e5436b84202a10eb",
-    "zh:ce9ba491e649f5e53f327dfb5b3d54cac370f44b95273ba4c46d0edadceaed33",
-    "zh:f1dadca8577deb4cf73271a96ca580cc58dd3b41e8d3b0c181e8a4a642c5a46a",
-  ]
-}


### PR DESCRIPTION
### Description:

This PR mainly addresses a host-only network issue encountered during Terraform deployments and includes two minor updates to the entry script.

The host-only network problem stemmed from a mismatch in the `virtualDev` setting between the initial Terraform configuration and the working configuration identified through manual GUI testing. Initially, the configuration used `vmxnet3`. It was discovered that using `e1000` was necessary for the network card to be recognized correctly, aligning the configuration with the Packer setup.

This issue was related to how VMware Workstation dynamically assigns network card names based on the PCI slot number, which itself is influenced by the `virtualDev` and the environment. After repeatedly building the Packer image and deploying Terraform, the **idempotency was confirmed** before hardcoding the network interface name to `ens32`. To prevent potential issues of hardcoding, the dynamically detected interface name throughout the configuration is introduced.  

### Changes:

- Refactored: Reconfigured all settings from VirtualBox to VMware Workstation. 
- Refactored: Switched the `virtualDev` for the host-only network from `vmxnet3` to `e1000` to ensure consistent and correct network card recognition.
- Refactored: Remove redundant restart provisioner since the VM has already started once before this block, after the `*.vmx` file has been modified.

- Optimized: The `sleep` duration were reduced to 5 seconds such that the average build time for each VM was reduced from 120 seconds to 80 seconds.
- Fixed: Corrected the path issue in the `/entry.sh` script.
- Fixed: To prevent the cache from growing indefinitely with build artifacts over time, the cleanup step is introduced.
- Fixed: Using the dynamically detected interface name throughout the configuration.
- Fixed: Removed `routes` and `nameservers` from `ens32` to allow `ens33`'s DHCP to automatically configure the default route and DNS. Also added `dhcp6: false` to disable IPv6, preventing unnecessary routing errors.

- Feature: Added a timer to the `/entry.sh` script to monitor execution time.