### PR TITLE
Experimental: Terraform to Ansible without using Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 packer/secret.auto.pkrvars.hcl
 *.tfvars
 
+# Ansible inventory
+ansible/inventory.yml
+ansible/inventory.yml.bak
+
 # Ignore folder for output *.vdi
 packer/output
 packer-playground/output
@@ -15,3 +19,4 @@ terraform/vms
 
 # VSCode
 .vscode
+commit-messge.md

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,11 @@ packer-playground/output
 .terraform/
 terraform.tfstate
 terraform.tfstate.backup
-
 terraform/vms
 
 # VSCode
 .vscode
 commit-messge.md
+vault_pass.txt
+
+ansible/group_vars/vault.yml

--- a/ansible/playbooks/setup_k8s.yml
+++ b/ansible/playbooks/setup_k8s.yml
@@ -1,0 +1,17 @@
+---
+- name: Setup Kubernetes cluster
+  hosts: all
+  become: true
+  vars_files:
+    - ../group_vars/all.yml
+  tasks:
+    - name: "1. Action: Execute system update"
+      ansible.builtin.apt:
+        update_cache: true
+        upgrade: dist
+        cache_valid_time: 3600
+      register: apt_result
+      retries: 3
+      delay: 5
+      until: apt_result is success
+      changed_when: apt_result.changed

--- a/ansible/templates/inventory.yml.tftpl
+++ b/ansible/templates/inventory.yml.tftpl
@@ -1,0 +1,17 @@
+---
+all:
+  children:
+    master:
+      hosts:
+        ${master_hostname}:
+          ansible_host: ${master_ip}
+          ansible_ssh_user: ${ssh_user}
+          ansible_ssh_private_key_file: "${ssh_key_path}"
+    workers:
+      hosts:
+        %{~ for i, ip in worker_ips ~}
+        ${worker_hostname_prefix}${split(".", ip)[3]}:
+          ansible_host: ${ip}
+          ansible_ssh_user: ${ssh_user}
+          ansible_ssh_private_key_file: "${ssh_key_path}"
+        %{~ endfor ~}

--- a/entry.sh
+++ b/entry.sh
@@ -5,11 +5,14 @@ set -e -u
 # Define Kubernetes Cluster IP Endings
 
 IP_ENDINGS=(200 210 211 212)
+TF_VAR_vm_username=$(whoami)
+user="${TF_VAR_vm_username:-$(whoami)}"
 
 ### READONLY: DO NOT MODIFY
 
 # Define global variables
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly ANSIBLE_DIR="${SCRIPT_DIR}/ansible"
 readonly TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 readonly PACKER_DIR="${SCRIPT_DIR}/packer"
 readonly PACKER_VM_NAME="ubuntu-server-24-template-vmware"
@@ -17,6 +20,146 @@ readonly PACKER_OUTPUT_DIR="${PACKER_DIR}/output/ubuntu-server-vmware"
 
 # Record start time at the beginning of the script
 readonly START_TIME=$(date +%s)
+
+# Function: Check IaC environment and return status
+check_iac_environment() {
+  echo ">>> STEP: Checking IaC environment..."
+  local all_installed=true
+  local vmware_version packer_version terraform_version ansible_version
+
+  # Check VMware Workstation
+  if command -v vmware >/dev/null 2>&1; then
+    vmware_version=$(vmware --version 2>/dev/null || echo "Unknown")
+    echo "#### VMware Workstation: Installed (Version: $vmware_version)"
+  else
+    vmware_version="Not installed"
+    all_installed=false
+    echo "#### VMware Workstation: Not installed"
+  fi
+
+  # Check Packer
+  if command -v packer >/dev/null 2>&1; then
+    packer_version=$(packer --version 2>/dev/null || echo "Unknown")
+    echo "#### Packer: Installed (Version: $packer_version)"
+  else
+    packer_version="Not installed"
+    all_installed=false
+    echo "#### Packer: Not installed"
+  fi
+
+  # Check Terraform
+  if command -v terraform >/dev/null 2>&1; then
+    terraform_version=$(terraform --version 2>/dev/null | head -n 1 || echo "Unknown")
+    echo "#### Terraform: Installed (Version: $terraform_version)"
+  else
+    terraform_version="Not installed"
+    all_installed=false
+    echo "#### Terraform: Not installed"
+  fi
+
+  # Check Ansible
+  if command -v ansible >/dev/null 2>&1; then
+    ansible_version=$(ansible --version 2>/dev/null | head -n 1 || echo "Unknown")
+    echo "#### Ansible: Installed (Version: $ansible_version)"
+  else
+    ansible_version="Not installed"
+    all_installed=false
+    echo "#### Ansible: Not installed"
+  fi
+
+  echo "--------------------------------------------------"
+  if $all_installed; then
+    echo "#### All required IaC tools are already installed."
+    read -p "###### Do you want to reinstall the IaC environment? (y/n): " reinstall_answer
+    if [[ ! "$reinstall_answer" =~ ^[Yy]$ ]]; then
+      echo "#### Skipping IaC environment installation."
+      return 1
+    fi
+  else
+    echo "#### Some IaC tools are missing or not installed."
+    read -p "###### Do you want to proceed with installing the IaC environment? (y/n): " install_answer
+    if [[ ! "$install_answer" =~ ^[Yy]$ ]]; then
+      echo "#### Skipping IaC environment installation."
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# Function: Setup IaC Environment
+setup_iac_environment() {
+    echo ">>> STEP: Setting up IaC environment..."
+
+    # Install VMware Workstation
+    echo "#### Installing VMware Workstation..."
+    sudo apt update
+    sudo apt install wget gnupg2 -y
+    wget https://www.vmware.com/go/getworkstation-linux -O vmware-workstation.bundle
+    chmod +x vmware-workstation.bundle
+    sudo ./vmware-workstation.bundle --eulas-agreed --required
+    echo "#### VMware Workstation installation completed."
+
+    # Install HashiCorp Toolkits (Terraform and Packer)
+    echo "#### Installing HashiCorp Toolkits (Terraform and Packer)..."
+    wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+    sudo apt update && sudo apt install terraform packer -y
+    echo "#### Terraform and Packer installation completed."
+
+    # Install Ansible
+    echo "#### Installing Ansible..."
+    sudo apt install software-properties-common -y
+    sudo add-apt-repository --yes --update ppa:ansible/ansible
+    sudo apt install ansible -y
+    echo "#### Ansible installation completed."
+
+    # Verify installations
+    echo "#### Verifying installed tools..."
+    echo "###### VMware Workstation version:"
+    vmware --version
+    echo "###### Packer version:"
+    packer --version
+    echo "###### Terraform version:"
+    terraform --version
+    echo "###### Ansible version:"
+    ansible --version
+    echo "#### IaC environment setup and verification completed."
+    echo "--------------------------------------------------"
+}
+
+# Function: Configure network setting of VMWare after environment setup
+
+set_workstation_network() {
+  # Prompt for VMware network configuration
+  echo ">>> VMware Network Editor configuration is required:"
+  echo "- Set vmnet8 to NAT with subnet 172.16.86.0/24 and DHCP enabled."
+  echo "- Set vmnet1 to Host-only with subnet 172.16.134.0/24 (no DHCP)."
+  read -p "Do you want to automatically configure VMware networking settings by modifying /etc/vmware/networking? (y/n): " answer
+  if [[ "$answer" =~ ^[Yy]$ ]]; then
+    echo "Configuring VMware networking settings..."
+    sudo /etc/init.d/vmware stop
+    cat << EOF | sudo tee /etc/vmware/networking
+VERSION=1,0
+answer VNET_1_DHCP no
+answer VNET_1_DISPLAY_NAME 
+answer VNET_1_HOSTONLY_NETMASK 255.255.255.0
+answer VNET_1_HOSTONLY_SUBNET 172.16.134.0
+answer VNET_1_VIRTUAL_ADAPTER yes
+answer VNET_8_DHCP yes
+answer VNET_8_DHCP_CFG_HASH B7DE0620494D07D87DE131EBECBC26E55A0AFD74
+answer VNET_8_DISPLAY_NAME 
+answer VNET_8_HOSTONLY_NETMASK 255.255.255.0
+answer VNET_8_HOSTONLY_SUBNET 172.16.86.0
+answer VNET_8_NAT yes
+answer VNET_8_VIRTUAL_ADAPTER yes
+EOF
+    sudo /etc/init.d/vmware start
+    echo "#### VMware networking configuration completed."
+  else
+    echo "#### Skipping automatic VMware networking configuration. Please configure manually using VMware Network Editor."
+  fi
+  echo "--------------------------------------------------"
+}
 
 # Function: Clean up VMware Workstation VM registrations
 cleanup_vmware_vms() {
@@ -36,11 +179,11 @@ cleanup_packer_output() {
   echo ">>> STEP: Cleaning Packer output directory..."
   cd "${PACKER_DIR}"
   if [ -d ~/.cache/packer ]; then
-    echo "Cleaning Packer cache, preserving ISOs..."
+    echo "####Cleaning Packer cache, preserving ISOs..."
     find ~/.cache/packer -mindepth 1 ! -name '*.iso' -exec rm -rf {} + || true
   fi
   rm -rf "${PACKER_OUTPUT_DIR}"
-  echo "Packer output directory cleaned."
+  echo "#### Packer output directory cleaned."
   echo "--------------------------------------------------"
 }
 
@@ -50,7 +193,7 @@ build_packer() {
   cd "${PACKER_DIR}"
   packer init .
   packer build -var-file=common.pkrvars.hcl .
-  echo "Packer build complete. New base image (VMX) is ready."
+  echo "#### Packer build complete. New base image (VMX) is ready."
   echo "--------------------------------------------------"
 }
 
@@ -63,7 +206,7 @@ reset_terraform_state() {
   rm -f .terraform.lock.hcl
   rm -f terraform.tfstate
   rm -f terraform.tfstate.backup
-  echo "Terraform state reset."
+  echo "#### Terraform state reset."
   echo "--------------------------------------------------"
 }
 
@@ -74,7 +217,7 @@ destroy_terraform_resources() {
   terraform init -upgrade
   terraform destroy -parallelism=1 -auto-approve -lock=false
   rm -rf "${TERRAFORM_DIR}/vms"
-  echo "Terraform destroy complete."
+  echo "#### Terraform destroy complete."
   echo "--------------------------------------------------"
 }
 
@@ -83,44 +226,53 @@ apply_terraform() {
   echo ">>> STEP: Initializing Terraform and applying configuration..."
   cd "${TERRAFORM_DIR}"
   terraform init
+  terraform validate
   terraform apply -parallelism=1 -auto-approve
-  echo "Terraform apply complete. New VMs are running."
+  echo "#### Terraform apply complete. New VMs are running."
   echo "--------------------------------------------------"
 }
 
 # Function: Verify SSH connections
 verify_ssh() {
   echo ">>> STEP: Pruning and reconfiguring SSH connections..."
-  user=$(whoami)
   known_hosts_file="/home/$user/.ssh/known_hosts"
 
-  if [ ${#IP_ENDINGS[@]} -eq 0 ]; then
-    echo "Error: IP_ENDINGS array is not set or is empty. Set the IP list at the top of the script"
+  # Read host aliases from ansible/inventory.yml
+  hosts=$(grep -E '^vm[0-9]+' "${ANSIBLE_DIR}/inventory.yml" | awk '{print $1}')
+  if [ -z "$hosts" ]; then
+    echo "#### Error: No hosts found in ${ANSIBLE_DIR}/inventory.yml"
     return 1
   fi
-  for ip in "${IP_ENDINGS[@]}"; do
-    host="172.16.134.$ip"
-    echo "Processing host: $host"
+
+  for host in $hosts; do
+    # Extract IP from inventory.yml for known_hosts cleanup
+    ip=$(grep "^$host " "${ANSIBLE_DIR}/inventory.yml" | grep -oP 'ansible_host=\K[\d.]+')
+    echo "#### Processing host: $host ($ip)"
     if [ -f "$known_hosts_file" ]; then
-      echo "Removing old keys for $host from $known_hosts_file..."
+      echo "###### Removing old keys for $host and $ip from $known_hosts_file..."
       ssh-keygen -f "$known_hosts_file" -R "$host" || true
+      [ -n "$ip" ] && ssh-keygen -f "$known_hosts_file" -R "$ip" || true
     else
-      echo "known_hosts file does not exist: $known_hosts_file"
+      echo "###### known_hosts file does not exist: $known_hosts_file"
     fi
-    echo "Connecting to $host via SSH and executing command..."
-    ssh -o ConnectTimeout=10 "$user@$host" "ip a show ens32 | grep 'inet ' && hostname" || echo "Failed to connect to $host or command execution failed."
-    sleep 5
+    echo "#### Connecting to $host via SSH and executing command..."
+    ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new "$host" "ip a show ens32 | grep 'inet ' && hostname" || echo "Failed to connect to $host or command execution failed."
+    sleep 2
   done
+
+  echo "#### Verifying Ansible connectivity..."
+  cd "${ANSIBLE_DIR}"
+  ansible -i inventory.yml all -m ping
   echo "--------------------------------------------------"
 }
 
 # Function: Check if user wants to verify SSH connections
 prompt_verify_ssh() {
-  read -p "Do you want to verify SSH connections? (y/n): " answer
+  read -p "#### Do you want to verify SSH connections? (y/n): " answer
   if [[ "$answer" =~ ^[Yy]$ ]]; then
     verify_ssh
   else
-    echo "Skipping SSH verification."
+    echo "#### Skipping SSH verification."
   fi
 }
 
@@ -132,41 +284,50 @@ report_execution_time() {
   MINUTES=$((DURATION / 60))
   SECONDS=$((DURATION % 60))
   echo "--------------------------------------------------"
-  echo ">>> Execution time before SSH prompt: ${MINUTES}m ${SECONDS}s"
+  echo ">>> Execution time: ${MINUTES}m ${SECONDS}s"
   echo "--------------------------------------------------"
 }
 
 # Main menu
 echo "VMware Workstation VM Management Script"
 PS3="Please select an action: "
-options=("Reset All" "Rebuild All" "Rebuild Packer" "Rebuild Terraform" "Verify SSH" "Quit")
+options=("Setup IaC Environment" "Reset All" "Rebuild All" "Rebuild Packer" "Rebuild Terraform" "Verify SSH" "Quit")
 select opt in "${options[@]}"; do
   case $opt in
+    "Setup IaC Environment")
+      echo "# Executing Setup IaC Environment workflow..."
+      check_iac_environment
+      setup_iac_environment
+      set_workstation_network
+      report_execution_time
+      echo "# Setup IaC Environment workflow completed successfully."
+      break
+      ;;
     "Reset All")
-      echo "Executing Reset All workflow..."
+      echo "# Executing Reset All workflow..."
       cleanup_vmware_vms
       destroy_terraform_resources
       cleanup_packer_output
       reset_terraform_state
       report_execution_time
-      echo "Reset All workflow completed successfully."
+      echo "# Reset All workflow completed successfully."
       break
       ;;
     "Rebuild All")
-      echo "Executing Rebuild All workflow..."
+      echo "# Executing Rebuild All workflow..."
       cleanup_vmware_vms
       destroy_terraform_resources
       cleanup_packer_output
       build_packer
       reset_terraform_state
       apply_terraform
+      verify_ssh
       report_execution_time
-      prompt_verify_ssh
-      echo "Rebuild All workflow completed successfully."
+      echo "# Rebuild All workflow completed successfully."
       break
       ;;
     "Rebuild Packer")
-      echo "Executing Rebuild Packer workflow..."
+      echo "# Executing Rebuild Packer workflow..."
       cleanup_vmware_vms
       cleanup_packer_output
       build_packer
@@ -174,25 +335,25 @@ select opt in "${options[@]}"; do
       break
       ;;
     "Rebuild Terraform")
-      echo "Executing Rebuild Terraform workflow..."
+      echo "# Executing Rebuild Terraform workflow..."
       destroy_terraform_resources
       reset_terraform_state
       apply_terraform
+      verify_ssh
       report_execution_time
-      prompt_verify_ssh
-      echo "Rebuild Terraform workflow completed successfully."
+      echo "# Rebuild Terraform workflow completed successfully."
       break
       ;;
     "Verify SSH")
-      echo "Executing Verify SSH workflow..."
-      verify_ssh
-      echo "Verify SSH workflow completed successfully."
+      echo "# Executing Verify SSH workflow..."
+      prompt_verify_ssh
+      echo "# Verify SSH workflow completed successfully."
       break
       ;;
     "Quit")
-      echo "Exiting script."
+      echo "# Exiting script."
       break
       ;;
-    *) echo "Invalid option $REPLY";;
+    *) echo "# Invalid option $REPLY";;
   esac
 done

--- a/entry.sh
+++ b/entry.sh
@@ -2,6 +2,12 @@
 
 set -e -u
 
+# Define Kubernetes Cluster IP Endings
+
+IP_ENDINGS=(200 210 211 212)
+
+### READONLY: DO NOT MODIFY
+
 # Define global variables
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
@@ -87,14 +93,17 @@ verify_ssh() {
   echo ">>> STEP: Pruning and reconfiguring SSH connections..."
   user=$(whoami)
   known_hosts_file="/home/$user/.ssh/known_hosts"
-  start_ip=101
-  end_ip=103
-  for ip in $(seq $start_ip $end_ip); do
+
+  if [ ${#IP_ENDINGS[@]} -eq 0 ]; then
+    echo "Error: IP_ENDINGS array is not set or is empty. Set the IP list at the top of the script"
+    return 1
+  fi
+  for ip in "${IP_ENDINGS[@]}"; do
     host="172.16.134.$ip"
     echo "Processing host: $host"
     if [ -f "$known_hosts_file" ]; then
       echo "Removing old keys for $host from $known_hosts_file..."
-      ssh-keygen -f "$known_hosts_file" -R "$host"
+      ssh-keygen -f "$known_hosts_file" -R "$host" || true
     else
       echo "known_hosts file does not exist: $known_hosts_file"
     fi

--- a/entry.sh
+++ b/entry.sh
@@ -24,7 +24,7 @@ cleanup_vmware_vms() {
   if vmrun list | grep -q "$PACKER_VM_NAME"; then
     echo "Found leftover Packer VM '$PACKER_VM_NAME'. Stopping and deleting..."
     vmrun stop "${PACKER_OUTPUT_DIR}/${PACKER_VM_NAME}.vmx" hard || true
-    vmrun delete "${PACKER_OUTPUT_DIR}/${PACKER_VM_NAME}.vmx" || true
+    vmrun deleteVM "${PACKER_OUTPUT_DIR}/${PACKER_VM_NAME}.vmx" || true
   else
     echo "No leftover Packer VM found. Skipping VMware cleanup."
   fi

--- a/terraform/configure_nodes.tf
+++ b/terraform/configure_nodes.tf
@@ -1,0 +1,79 @@
+resource "null_resource" "configure_nodes" {
+  depends_on = [null_resource.generate_ssh_config]
+  for_each = { for node in local.all_nodes : node.key => node }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      rm -rf ${local.vms_dir}/${each.key}
+      mkdir -p ${local.vms_dir}/${each.key}
+      vmrun -T ws clone ${local.vmx_image_path} ${each.value.path} full -cloneName=${each.key}
+      sed -i '/^numvcpus/d' ${each.value.path}
+      sed -i '/^memsize/d' ${each.value.path}
+      echo 'numvcpus = "${each.value.vcpu}"' >> ${each.value.path}
+      echo 'memsize = "${each.value.ram}"' >> ${each.value.path}
+      sed -i '/^ethernet1\./d' ${each.value.path}
+      echo 'ethernet1.present = "TRUE"' >> ${each.value.path}
+      echo 'ethernet1.connectionType = "hostonly"' >> ${each.value.path}
+      echo 'ethernet1.virtualDev = "e1000"' >> ${each.value.path}
+      vmrun -T ws start ${each.value.path} nogui
+      sleep 10
+      vmrun -T ws getGuestIPAddress ${each.value.path} -wait > ${local.vms_dir}/${each.key}/nat_ip.txt || true
+    EOT
+  }
+
+  provisioner "remote-exec" {
+    connection {
+      type     = "ssh"
+      user     = var.vm_username
+      password = var.vm_password
+      host     = try(trimspace(file("${local.vms_dir}/${each.key}/nat_ip.txt")), "failed")
+      port     = 22
+      timeout  = "10m"
+      agent    = false
+    }
+
+    inline = [
+      # Wait for SSH and network to stabilize
+      "sleep 5",
+      # Clear cloud-init state to prevent reset
+      "sudo cloud-init clean --logs || true",
+      "sudo systemctl disable cloud-init || true",
+      "sudo systemctl stop cloud-init || true",
+      "sudo touch /etc/cloud/cloud-init.disabled || true",
+      # Reload network drivers and bring up host-only interface
+      "sudo modprobe e1000 || true",
+      "sudo udevadm trigger || true",
+      # Detect the host-only network interface
+      "HOSTONLY_IFACE=$(ip -o link show | awk -F': ' '{print $2}' | grep -v -e '^lo$' -e '^ens33$' | head -n 1)",
+      "if [ -z \"$HOSTONLY_IFACE\" ]; then echo 'Error: Host-only network interface not found'; ip -o link show; exit 1; fi",
+      # Configure Netplan with NAT handling external traffic
+      "echo 'network:\n  version: 2\n  ethernets:\n    ens33:\n      dhcp4: true\n      dhcp6: false\n    ens32:\n      dhcp4: false\n      addresses: [${each.value.ip}/24]' | sudo tee /etc/netplan/00-hostonly.yaml",
+      "sudo chmod 600 /etc/netplan/00-hostonly.yaml",
+      # Apply Netplan configuration with error checking and delay
+      "if ! sudo netplan apply; then echo 'Error: netplan apply failed'; cat /etc/netplan/00-hostonly.yaml; exit 1; fi",
+      "sleep 5",
+      # Set hostname
+      "sudo hostnamectl set-hostname ${each.key}",
+      # Configure SSH public key and service
+      "mkdir -p ~/.ssh",
+      "chmod 700 ~/.ssh",
+      "echo '${file("~/.ssh/id_ed25519_k8s-cluster.pub")}' > ~/.ssh/authorized_keys",
+      "chmod 600 ~/.ssh/authorized_keys",
+      # Ensure home directory permissions
+      "chmod 755 /home/${var.vm_username}",
+      # Configure sshd
+      "sudo sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config",
+      "sudo sed -i 's/#AuthorizedKeysFile/AuthorizedKeysFile/' /etc/ssh/sshd_config",
+      # Verify SSH public key
+      "sudo systemctl restart sshd"
+    ]
+
+    on_failure = continue
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      vmrun -T ws stop ${each.value.path} hard || true
+    EOT
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,96 +53,6 @@ resource "null_resource" "generate_ssh_config" {
   }
 }
 
-resource "null_resource" "configure_nodes" {
-  depends_on = [null_resource.generate_ssh_config]
-  for_each = { for node in local.all_nodes : node.key => node }
-
-  provisioner "local-exec" {
-    command = <<EOT
-      rm -rf ${local.vms_dir}/${each.key}
-      mkdir -p ${local.vms_dir}/${each.key}
-      vmrun -T ws clone ${local.vmx_image_path} ${each.value.path} full -cloneName=${each.key}
-      sed -i '/^numvcpus/d' ${each.value.path}
-      sed -i '/^memsize/d' ${each.value.path}
-      echo 'numvcpus = "${each.value.vcpu}"' >> ${each.value.path}
-      echo 'memsize = "${each.value.ram}"' >> ${each.value.path}
-      sed -i '/^ethernet1\./d' ${each.value.path}
-      echo 'ethernet1.present = "TRUE"' >> ${each.value.path}
-      echo 'ethernet1.connectionType = "hostonly"' >> ${each.value.path}
-      echo 'ethernet1.virtualDev = "e1000"' >> ${each.value.path}
-      vmrun -T ws start ${each.value.path} nogui
-      sleep 10
-      vmrun -T ws getGuestIPAddress ${each.value.path} -wait > ${local.vms_dir}/${each.key}/nat_ip.txt || true
-    EOT
-  }
-
-  provisioner "remote-exec" {
-    connection {
-      type     = "ssh"
-      user     = var.vm_username
-      password = var.vm_password
-      host     = try(trimspace(file("${local.vms_dir}/${each.key}/nat_ip.txt")), "failed")
-      port     = 22
-      timeout  = "10m"
-      agent    = false
-    }
-
-    inline = [
-      # Wait for SSH and network to stabilize
-      "sleep 5",
-      # Clear cloud-init state to prevent reset
-      "sudo cloud-init clean --logs || true",
-      "sudo systemctl disable cloud-init || true",
-      "sudo systemctl stop cloud-init || true",
-      "sudo touch /etc/cloud/cloud-init.disabled || true",
-      # Reload network drivers and bring up host-only interface
-      "sudo modprobe e1000 || true",
-      "sudo udevadm trigger || true",
-      # Detect the host-only network interface
-      "HOSTONLY_IFACE=$(ip -o link show | awk -F': ' '{print $2}' | grep -v -e '^lo$' -e '^ens33$' | head -n 1)",
-      "if [ -z \"$HOSTONLY_IFACE\" ]; then echo 'Error: Host-only network interface not found'; ip -o link show; exit 1; fi",
-      # Configure Netplan with NAT handling external traffic
-      "echo 'network:\n  version: 2\n  ethernets:\n    ens33:\n      dhcp4: true\n      dhcp6: false\n    ens32:\n      dhcp4: false\n      addresses: [${each.value.ip}/24]' | sudo tee /etc/netplan/00-hostonly.yaml",
-      "sudo chmod 600 /etc/netplan/00-hostonly.yaml",
-      # Apply Netplan configuration with error checking and delay
-      "if ! sudo netplan apply; then echo 'Error: netplan apply failed'; cat /etc/netplan/00-hostonly.yaml; exit 1; fi",
-      "sleep 5",
-      # Set hostname
-      "sudo hostnamectl set-hostname ${each.key}",
-      # Verify hostname
-      "echo 'Verifying hostname for ${each.key}'",
-      "hostname | grep -i ${each.key} || echo 'Warning: Hostname mismatch for ${each.key}'",
-      # Verify network interfaces
-      "ip a show ens33 || echo 'Warning: ens33 not found'",
-      "ip a show \"$HOSTONLY_IFACE\" || echo 'Warning: host-only interface not found'",
-      # Verify IP
-      "sleep 5",
-      "ip a show \"$HOSTONLY_IFACE\" | grep ${each.value.ip} || echo 'Warning: host-only IP not set'",
-      # Configure SSH public key and service
-      "mkdir -p ~/.ssh",
-      "chmod 700 ~/.ssh",
-      "echo '${file("~/.ssh/id_ed25519_k8s-cluster.pub")}' > ~/.ssh/authorized_keys",
-      "chmod 600 ~/.ssh/authorized_keys",
-      # Ensure home directory permissions
-      "chmod 755 /home/${var.vm_username}",
-      # Configure sshd
-      "sudo sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config",
-      "sudo sed -i 's/#AuthorizedKeysFile/AuthorizedKeysFile/' /etc/ssh/sshd_config",
-      "sudo systemctl restart sshd",
-      # Verify SSH public key
-      "grep -q '${file("~/.ssh/id_ed25519_k8s-cluster.pub")}' ~/.ssh/authorized_keys || echo 'Warning: Failed to add SSH public key'"
-    ]
-
-    on_failure = continue
-  }
-
-  provisioner "local-exec" {
-    command = <<EOT
-      vmrun -T ws stop ${each.value.path} hard || true
-    EOT
-  }
-}
-
 resource "null_resource" "start_all_vms" {
   depends_on = [null_resource.configure_nodes]
 
@@ -152,8 +62,6 @@ resource "null_resource" "start_all_vms" {
       ${join("\n", [for node in local.all_nodes : "vmrun -T ws start ${node.path} || echo 'Warning: Failed to start ${node.key}'"])}
       sleep 10
       echo "All VMs started."
-      # Verify passwordless SSH
-      ${join("\n", [for node in local.all_nodes : "ssh -o BatchMode=yes -o ConnectTimeout=10 vm${split(".", node.ip)[3]} hostname || echo 'Warning: Passwordless SSH failed for ${node.key}'"])}
     EOT
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,7 +36,25 @@ locals {
   all_nodes = concat(local.master_config, local.workers_config)
 }
 
+resource "null_resource" "generate_ssh_config" {
+  provisioner "local-exec" {
+    command = <<EOT
+      mkdir -p ~/.ssh
+      if [ ! -f ~/.ssh/id_ed25519_k8s-cluster ]; then
+        ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_k8s-cluster -N "" -C "k8s-cluster-key"
+      fi
+      echo "# SSH configuration for Kubernetes cluster" > ~/.ssh/config
+      chmod 600 ~/.ssh/config
+      ${join("\n", [
+        for node in local.all_nodes :
+        "echo 'Host vm${split(".", node.ip)[3]}\n  HostName ${node.ip}\n  User ${var.vm_username}\n  IdentityFile ~/.ssh/id_ed25519_k8s-cluster' >> ~/.ssh/config"
+      ])}
+    EOT
+  }
+}
+
 resource "null_resource" "configure_nodes" {
+  depends_on = [null_resource.generate_ssh_config]
   for_each = { for node in local.all_nodes : node.key => node }
 
   provisioner "local-exec" {
@@ -52,7 +70,7 @@ resource "null_resource" "configure_nodes" {
       echo 'ethernet1.present = "TRUE"' >> ${each.value.path}
       echo 'ethernet1.connectionType = "hostonly"' >> ${each.value.path}
       echo 'ethernet1.virtualDev = "e1000"' >> ${each.value.path}
-      vmrun -T ws start ${each.value.path}
+      vmrun -T ws start ${each.value.path} nogui
       sleep 10
       vmrun -T ws getGuestIPAddress ${each.value.path} -wait > ${local.vms_dir}/${each.key}/nat_ip.txt || true
     EOT
@@ -70,26 +88,49 @@ resource "null_resource" "configure_nodes" {
     }
 
     inline = [
+      # Wait for SSH and network to stabilize
       "sleep 5",
+      # Clear cloud-init state to prevent reset
       "sudo cloud-init clean --logs || true",
       "sudo systemctl disable cloud-init || true",
       "sudo systemctl stop cloud-init || true",
       "sudo touch /etc/cloud/cloud-init.disabled || true",
+      # Reload network drivers and bring up host-only interface
       "sudo modprobe e1000 || true",
       "sudo udevadm trigger || true",
+      # Detect the host-only network interface
       "HOSTONLY_IFACE=$(ip -o link show | awk -F': ' '{print $2}' | grep -v -e '^lo$' -e '^ens33$' | head -n 1)",
       "if [ -z \"$HOSTONLY_IFACE\" ]; then echo 'Error: Host-only network interface not found'; ip -o link show; exit 1; fi",
+      # Configure Netplan with NAT handling external traffic
       "echo 'network:\n  version: 2\n  ethernets:\n    ens33:\n      dhcp4: true\n      dhcp6: false\n    ens32:\n      dhcp4: false\n      addresses: [${each.value.ip}/24]' | sudo tee /etc/netplan/00-hostonly.yaml",
       "sudo chmod 600 /etc/netplan/00-hostonly.yaml",
+      # Apply Netplan configuration with error checking and delay
       "if ! sudo netplan apply; then echo 'Error: netplan apply failed'; cat /etc/netplan/00-hostonly.yaml; exit 1; fi",
       "sleep 5",
+      # Set hostname
       "sudo hostnamectl set-hostname ${each.key}",
+      # Verify hostname
       "echo 'Verifying hostname for ${each.key}'",
       "hostname | grep -i ${each.key} || echo 'Warning: Hostname mismatch for ${each.key}'",
+      # Verify network interfaces
       "ip a show ens33 || echo 'Warning: ens33 not found'",
       "ip a show \"$HOSTONLY_IFACE\" || echo 'Warning: host-only interface not found'",
+      # Verify IP
       "sleep 5",
-      "ip a show \"$HOSTONLY_IFACE\" | grep ${each.value.ip} || echo 'Warning: host-only IP not set'"
+      "ip a show \"$HOSTONLY_IFACE\" | grep ${each.value.ip} || echo 'Warning: host-only IP not set'",
+      # Configure SSH public key and service
+      "mkdir -p ~/.ssh",
+      "chmod 700 ~/.ssh",
+      "echo '${file("~/.ssh/id_ed25519_k8s-cluster.pub")}' > ~/.ssh/authorized_keys",
+      "chmod 600 ~/.ssh/authorized_keys",
+      # Ensure home directory permissions
+      "chmod 755 /home/${var.vm_username}",
+      # Configure sshd
+      "sudo sed -i 's/#PubkeyAuthentication yes/PubkeyAuthentication yes/' /etc/ssh/sshd_config",
+      "sudo sed -i 's/#AuthorizedKeysFile/AuthorizedKeysFile/' /etc/ssh/sshd_config",
+      "sudo systemctl restart sshd",
+      # Verify SSH public key
+      "grep -q '${file("~/.ssh/id_ed25519_k8s-cluster.pub")}' ~/.ssh/authorized_keys || echo 'Warning: Failed to add SSH public key'"
     ]
 
     on_failure = continue
@@ -111,6 +152,8 @@ resource "null_resource" "start_all_vms" {
       ${join("\n", [for node in local.all_nodes : "vmrun -T ws start ${node.path} || echo 'Warning: Failed to start ${node.key}'"])}
       sleep 10
       echo "All VMs started."
+      # Verify passwordless SSH
+      ${join("\n", [for node in local.all_nodes : "ssh -o BatchMode=yes -o ConnectTimeout=10 vm${split(".", node.ip)[3]} hostname || echo 'Warning: Passwordless SSH failed for ${node.key}'"])}
     EOT
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,59 +8,56 @@ terraform {
 }
 
 locals {
-  ip_list = ["172.16.134.101", "172.16.134.102", "172.16.134.103"]
-  vmx_image_path = abspath("${path.root}/../packer/output/ubuntu-server-vmware/ubuntu-server-24-template-vmware.vmx")
   vms_dir = "${path.root}/vms"
+  master_ip_list = var.master_ip_list
+  worker_ip_list = var.worker_ip_list
+  vmx_image_path = abspath("${path.root}/../packer/output/ubuntu-server-vmware/ubuntu-server-24-template-vmware.vmx")
 
-  nodes_list = [
-    for idx in range(length(local.ip_list)) : {
-      key     = "node-${idx + 1}"
-      ip      = local.ip_list[idx]
+  master_config = [
+    for idx, ip in local.master_ip_list : {
+      key       = "k8s-master"
+      ip        = ip
+      vcpu      = var.master_vcpu
+      ram       = var.master_ram
+      path      = "${local.vms_dir}/k8s-master-${format("%02d", idx)}/k8s-master-${format("%02d", idx)}.vmx"
     }
   ]
+
+  workers_config = [
+    for idx, ip in local.worker_ip_list : {
+      key       = "k8s-worker-${format("%02d", idx)}"
+      ip        = ip
+      vcpu      = var.worker_vcpu
+      ram       = var.worker_ram
+      path      = "${local.vms_dir}/k8s-worker-${format("%02d", idx)}/k8s-worker-${format("%02d", idx)}.vmx"
+    }
+  ]
+
+  all_nodes = concat(local.master_config, local.workers_config)
 }
 
-resource "null_resource" "k8s_nodes" {
-  for_each = { for idx, node in local.nodes_list : node.key => node }
+resource "null_resource" "configure_nodes" {
+  for_each = { for node in local.all_nodes : node.key => node }
 
-  # Clean up existing VM directory and clone VM
   provisioner "local-exec" {
     command = <<EOT
       rm -rf ${local.vms_dir}/${each.key}
       mkdir -p ${local.vms_dir}/${each.key}
-      vmrun -T ws clone ${local.vmx_image_path} ${local.vms_dir}/${each.key}/${each.key}.vmx full -cloneName=${each.key}
-      # Add host-only network adapter (vmnet1) mimicking GUI
-      sed -i '/^ethernet1\./d' ${local.vms_dir}/${each.key}/${each.key}.vmx
-      echo 'ethernet1.present = "TRUE"' >> ${local.vms_dir}/${each.key}/${each.key}.vmx
-      echo 'ethernet1.connectionType = "hostonly"' >> ${local.vms_dir}/${each.key}/${each.key}.vmx
-      echo 'ethernet1.virtualDev = "e1000"' >> ${local.vms_dir}/${each.key}/${each.key}.vmx
+      vmrun -T ws clone ${local.vmx_image_path} ${each.value.path} full -cloneName=${each.key}
+      sed -i '/^numvcpus/d' ${each.value.path}
+      sed -i '/^memsize/d' ${each.value.path}
+      echo 'numvcpus = "${each.value.vcpu}"' >> ${each.value.path}
+      echo 'memsize = "${each.value.ram}"' >> ${each.value.path}
+      sed -i '/^ethernet1\./d' ${each.value.path}
+      echo 'ethernet1.present = "TRUE"' >> ${each.value.path}
+      echo 'ethernet1.connectionType = "hostonly"' >> ${each.value.path}
+      echo 'ethernet1.virtualDev = "e1000"' >> ${each.value.path}
+      vmrun -T ws start ${each.value.path}
+      sleep 10
+      vmrun -T ws getGuestIPAddress ${each.value.path} -wait > ${local.vms_dir}/${each.key}/nat_ip.txt || true
     EOT
   }
 
-  # Shut down VM if running
-  provisioner "local-exec" {
-    command = <<EOT
-      vmrun -T ws list | grep ${each.key} && vmrun -T ws stop ${local.vms_dir}/${each.key}/${each.key}.vmx hard || true
-      sleep 5
-    EOT
-  }
-
-  # Start the VM to initialize
-  provisioner "local-exec" {
-    command = <<EOT
-      vmrun -T ws start ${local.vms_dir}/${each.key}/${each.key}.vmx nogui
-      sleep 5
-    EOT
-  }
-
-  # Get NAT IP dynamically
-  provisioner "local-exec" {
-    command = <<EOT
-      vmrun -T ws getGuestIPAddress ${local.vms_dir}/${each.key}/${each.key}.vmx -wait > ${local.vms_dir}/${each.key}/nat_ip.txt || true
-    EOT
-  }
-
-  # Configure network and hostname
   provisioner "remote-exec" {
     connection {
       type     = "ssh"
@@ -71,72 +68,49 @@ resource "null_resource" "k8s_nodes" {
       timeout  = "10m"
       agent    = false
     }
-        inline = [
-      # Wait for SSH and network to stabilize
+
+    inline = [
       "sleep 5",
-      # Clear cloud-init state to prevent reset
       "sudo cloud-init clean --logs || true",
       "sudo systemctl disable cloud-init || true",
       "sudo systemctl stop cloud-init || true",
       "sudo touch /etc/cloud/cloud-init.disabled || true",
-      # Reload network drivers and bring up host-only interface
       "sudo modprobe e1000 || true",
       "sudo udevadm trigger || true",
-      # Detect the host-only network interface
       "HOSTONLY_IFACE=$(ip -o link show | awk -F': ' '{print $2}' | grep -v -e '^lo$' -e '^ens33$' | head -n 1)",
       "if [ -z \"$HOSTONLY_IFACE\" ]; then echo 'Error: Host-only network interface not found'; ip -o link show; exit 1; fi",
-      # Configure Netplan with NAT handling external traffic
       "echo 'network:\n  version: 2\n  ethernets:\n    ens33:\n      dhcp4: true\n      dhcp6: false\n    ens32:\n      dhcp4: false\n      addresses: [${each.value.ip}/24]' | sudo tee /etc/netplan/00-hostonly.yaml",
       "sudo chmod 600 /etc/netplan/00-hostonly.yaml",
-      # Apply Netplan configuration with error checking and delay
       "if ! sudo netplan apply; then echo 'Error: netplan apply failed'; cat /etc/netplan/00-hostonly.yaml; exit 1; fi",
       "sleep 5",
-      # Set hostname
       "sudo hostnamectl set-hostname ${each.key}",
-      # Verify hostname
       "echo 'Verifying hostname for ${each.key}'",
       "hostname | grep -i ${each.key} || echo 'Warning: Hostname mismatch for ${each.key}'",
-      # Verify network interfaces
       "ip a show ens33 || echo 'Warning: ens33 not found'",
       "ip a show \"$HOSTONLY_IFACE\" || echo 'Warning: host-only interface not found'",
-      # Verify IP
       "sleep 5",
       "ip a show \"$HOSTONLY_IFACE\" | grep ${each.value.ip} || echo 'Warning: host-only IP not set'"
     ]
-    on_failure = continue # Bypass SSH disconnection errors
+
+    on_failure = continue
   }
 
-  # Ensure VM is stopped after configuration
   provisioner "local-exec" {
     command = <<EOT
-      vmrun -T ws stop ${local.vms_dir}/${each.key}/${each.key}.vmx hard || true
+      vmrun -T ws stop ${each.value.path} hard || true
     EOT
   }
 }
 
-# Global provisioner to start all VMs after configuration
 resource "null_resource" "start_all_vms" {
-  depends_on = [null_resource.k8s_nodes]
+  depends_on = [null_resource.configure_nodes]
 
   provisioner "local-exec" {
     command = <<EOT
       echo ">>> STEP: Starting all VMs after configuration..."
-      ${join("\n", [for node in local.nodes_list : "vmrun -T ws start ${local.vms_dir}/${node.key}/${node.key}.vmx nogui || echo 'Warning: Failed to start ${node.key}'"])}
-      # Add delay to ensure network stability
+      ${join("\n", [for node in local.all_nodes : "vmrun -T ws start ${node.path} || echo 'Warning: Failed to start ${node.key}'"])}
       sleep 10
       echo "All VMs started."
     EOT
-  }
-}
-
-output "instance_details" {
-  description = "Connection details and IP addresses for the deployed VMs"
-  sensitive   = true
-  value = {
-    for key, node in local.nodes_list :
-    key => {
-      ip_address   = node.ip
-      ssh_command  = "ssh ${var.vm_username}@${node.ip}"
-    }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,7 @@ locals {
 
   master_config = [
     for idx, ip in local.master_ip_list : {
-      key       = "k8s-master"
+      key       = "k8s-master-${format("%02d", idx)}"
       ip        = ip
       vcpu      = var.master_vcpu
       ram       = var.master_ram

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,21 @@
+output "master_details" {
+  description = "Connection details and IP address for the Kubernetes master node"
+  sensitive   = true
+  value = {
+    for node in local.master_config : node.key => {
+      ip_address  = node.ip
+      ssh_command = "ssh ${var.vm_username}@${node.ip}"
+    }
+  }
+}
+
+output "workers_details" {
+  description = "Connection details and IP addresses for the Kubernetes worker nodes"
+  sensitive   = true
+  value = {
+    for node in local.workers_config : node.key => {
+      ip_address  = node.ip
+      ssh_command = "ssh ${var.vm_username}@${node.ip}"
+    }
+  }
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,6 +1,6 @@
 output "master_details" {
   description = "Connection details and IP address for the Kubernetes master node"
-  sensitive   = true
+  sensitive   = false
   value = {
     for node in local.master_config : node.key => {
       ip_address  = node.ip
@@ -11,7 +11,7 @@ output "master_details" {
 
 output "workers_details" {
   description = "Connection details and IP addresses for the Kubernetes worker nodes"
-  sensitive   = true
+  sensitive   = false
   value = {
     for node in local.workers_config : node.key => {
       ip_address  = node.ip

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,5 @@
+### Variables for SSH login
+
 variable "vm_username" {
   description = "Username for SSH access to the VMs"
   type        = string
@@ -8,4 +10,45 @@ variable "vm_password" {
   description = "Password for SSH access to the VMs"
   type        = string
   sensitive   = true
+}
+
+### Variables to Configure IP Addresses for Master Node(s) and Worker Nodes. 
+
+variable "master_ip_list" {
+  description = "IP address list for the Kubernetes master node"
+  type        = list(string)
+  # Add IP for setting up High Abilities
+  default     = ["172.16.134.200"]
+}
+
+variable "worker_ip_list" {
+  description = "IP address list for the Kubernetes worker nodes"
+  type        = list(string)
+  default     = ["172.16.134.210", "172.16.134.211", "172.16.134.212"]
+}
+
+### Configure Resources for the Infrastructure 
+
+variable "master_vcpu" {
+  description = "Number of vCPUs for the Kubernetes master node"
+  type        = number
+  default     = 4
+}
+
+variable "master_ram" {
+  description = "Amount of RAM (in MB) for the Kubernetes master node"
+  type        = number
+  default     = 6144
+}
+
+variable "worker_vcpu" {
+  description = "Number of vCPUs for each Kubernetes worker node"
+  type        = number
+  default     = 6
+}
+
+variable "worker_ram" {
+  description = "Amount of RAM (in MB) for each Kubernetes worker node"
+  type        = number
+  default     = 12288
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@
 variable "vm_username" {
   description = "Username for SSH access to the VMs"
   type        = string
-  sensitive   = true
+  sensitive   = false
 }
 
 variable "vm_password" {


### PR DESCRIPTION
### Descirption

The initial Proof of Concept, which orchestrates the entire deployment process from Packer to Terraform and Ansible, is now complete. Due to an unresolved resource conflict with the community VMWare provider (`elsudano/vmworkstation`), this implementation utilized Terraform's `local-exec` provisioner to wrap `vmrun` CLI commands, achieving the core objectives.

To simplify the environment, the setup is currently configured for a single user, defaulting to `$(whoami)`. This approach aims to minimize user configuration effort and is tracked through Shell scripts. Future work will include clear documentation in `README.md` to outline the methodology and address how to maintain idempotency in a multi-user, multi-node environment in a user-friendly manner.

The Master and Worker nodes are designed for dynamic scalability. High Availability at the infrastructure layer can be achieved by simply adding Master node IP addresses in `terraform/variables.tf`. Terraform is also configured to automatically generate `ansible/inventory.yml` based on node settings, serving as the entry point for subsequent configuration management. To streamline SSH access, the configuration automatically generates a host-side `~/.ssh/config` file for all cluster nodes, enabling passwordless login with simple aliases like `ssh vm200` using public key authentication. To enable Ansible to connect to VMs via SSH public key, the `entry.sh` script integrates a Vault initialization process, guiding the user to set an encryption password and automatically generating the corresponding `vault.yml` and password file, which are then added to `.gitignore`.

With these integrations, a basic `setup_k8s.yml` playbook (performing `apt update`) has been successfully tested and can be executed five times idempotently on the host. Further adjustments will be made to Ansible's ping-pong test to suppress recurring `known_host` warnings in the terminal.

Finally, to enhance robustness, a fail-safe mechanism has been added to `./entry.sh`. All options that perform VM-related operations now require a successful VMWare Workstation environment check. If the environment is not installed, the script will `exit 1`. The functionality to configure HTTPS for the VM REST API is still pending and is expected to be a script-intensive task, necessitating further refactoring of the `./entry.sh` script.

### Changes:

- Implemented: Set up extendable Master and Worker nodes. The cluster can be expanded by adding IP addresses to the `master_ip_list` and `worker_ip_list` variables in `terraform/variables.tf`.
- Implemented: Terraform can now output `ansible/inventory.yml` and has passed the ping-pong test. This file contains sensitive information and is generated by Terraform, so it will not be added to version control.
- Implemented: Ansible can now connect directly to the virtual machines via public key authentication. A basic `ansible/playbooks/setup_k8s.yml` playbook (containing only `sudo apt update`) has been successfully tested.
- Implemented: Generated `ansible/inventory.yml` from `ansible/templates/inventory.yml.tftpl` within `terraform/main.tf`. This file has been added to `.gitignore`.

- Modified: Configured the resources to be used in the cluster.
- Modified: Updated SSH verification in `entry.sh` to require only the `IP_ENDINGS` of each node. This is acceptable for the current situation.
- Modified: The `verify_ssh()` function is now executed automatically after completing the "Rebuild Terraform" and "Rebuild All" options, and the timer now also includes the SSH verification time.
- Modified: The `prompt_verify_ssh()` function is now called only when the "Verify SSH" option is explicitly chosen.

- Feature: Automatically generated ~/.ssh/config for passwordless connections. Connection details can be checked by running `cat ~/.ssh/config`.
- Feature: Added an option to directly configure HTTPS for the VM REST API, though its stability still needs to be verified.
- Feature: Added the ability to configure Ansible Vault directly through `./entry.sh`. After entering a password, the script outputs `vault_pass.txt` and `ansible/group_vars/vault.yml`, both of which are added to `.gitignore`.
- Feature: Added an environment check for VMWare Workstation Pro. If the environment is not detected, no virtual machine-related operations can be performed.
- Feature: Added logic for checking and installing the IaC environment. This is currently executed only for the "Setup IaC Environment" option, as other options would fail without the necessary packages installed, making a check redundant.

- Fixed: `vmrun deleteVM` command according to <https://techdocs.broadcom.com/>
- Fixed: Set the vm_username variable in terraform/variables.tf to `sensitive = false` to prevent the recurring "(output suppressed due to sensitive value in config)" message in the terminal. The corresponding change was also made in `terraform/output.tf`.
- Fixed: Removed several debug messages.
- Refactored: Moved the `"null_resource" "configure_nodes"` block to a separate file, `terraform/configure_nodes.tf`, to maintain a cleaner `terraform/main.tf`.
- Finalize Terraform configuration for Kubernetes cluster setup

- Refactored: Integrated the simplified `ssh vm200` login (configured by generating `~/.ssh/config` in Terraform) into the `verify_ssh()` function.

- To-do: Integrate the Ansible ping-pong test into the `./entry.sh` workflow.
- To-do: Migrate all brute-force Ansible handling via `local-exec` to the official Ansible Provider (`ansible/ansible`).

- Note: An attempt was made to use the `elsudano/vmworkstation` Provider following the author's provided boilerplate, but this resulted in a resource conflict (the cause was not found). Therefore, the virtual machine setup was implemented entirely using a combination of `local-exec` and `remote-exec`.